### PR TITLE
Scala 2.12 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.polynote"
 name := "uzhttp"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.11.12"
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.3")
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 val zioVersion = "1.0.0-RC18-2"
 


### PR DESCRIPTION
Fixes compile issues on Scala 2.12, due to the deprecation of `PartialFunction.apply`. There are more compile errors on 2.13 but some are tricky because they need stuff that is not in 2.11 😞 