### PR TITLE
Fix for cross-building on 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.polynote"
 name := "uzhttp"
 version := "0.1.0-SNAPSHOT"
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.1"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 val zioVersion = "1.0.0-RC18-2"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.polynote"
 name := "uzhttp"
 version := "0.1.0-SNAPSHOT"
-scalaVersion := "2.13.1"
+scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 val zioVersion = "1.0.0-RC18-2"

--- a/src/main/scala-2.11/uzhttp/header/CompatMap.scala
+++ b/src/main/scala-2.11/uzhttp/header/CompatMap.scala
@@ -1,0 +1,6 @@
+package uzhttp.header
+
+trait CompatMap[K, V] extends scala.collection.immutable.Map[K, V] {
+  def removed(key: K): Map[K, V]
+  final def -(key: K): Map[K, V] = removed(key)
+}

--- a/src/main/scala-2.12/uzhttp/header/CompatMap.scala
+++ b/src/main/scala-2.12/uzhttp/header/CompatMap.scala
@@ -1,0 +1,6 @@
+package uzhttp.header
+
+trait CompatMap[K, V] extends scala.collection.immutable.Map[K, V] {
+  def removed(key: K): Map[K, V]
+  final def -(key: K): Map[K, V] = removed(key)
+}

--- a/src/main/scala-2.13/uzhttp/header/CompatMap.scala
+++ b/src/main/scala-2.13/uzhttp/header/CompatMap.scala
@@ -1,0 +1,3 @@
+package uzhttp.header
+
+trait CompatMap[K, V] extends scala.collection.immutable.Map[K, V]

--- a/src/main/scala/uzhttp/header/Headers.scala
+++ b/src/main/scala/uzhttp/header/Headers.scala
@@ -5,13 +5,14 @@ import uzhttp.server.BadRequest
 import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
 
-final class Headers private (private val mapWithLowerCaseKeys: Map[String, (String, String)]) extends scala.collection.immutable.Map[String, String] with Serializable {
-  override def +[B1 >: String](kv: (String, B1)): Headers = new Headers(mapWithLowerCaseKeys + (kv._1.toLowerCase -> (kv._1 -> kv._2.toString)))
+final class Headers private (private val mapWithLowerCaseKeys: Map[String, (String, String)]) extends CompatMap[String, String] with scala.collection.immutable.Map[String, String] with Serializable {
+  override def updated[V1 >: String](key: String, value: V1): Headers = new Headers(mapWithLowerCaseKeys + (key.toLowerCase -> (key -> value.toString)))
+  override def +[B1 >: String](kv: (String, B1)): Headers = updated(kv._1, kv._2)
   override def get(key: String): Option[String] = mapWithLowerCaseKeys.get(key.toLowerCase()).map(_._2)
   override def iterator: Iterator[(String, String)] = mapWithLowerCaseKeys.iterator.map {
     case (_, origKeyWithValue) => origKeyWithValue
   }
-  override def -(key: String): Map[String, String] = new Headers(mapWithLowerCaseKeys - key.toLowerCase)
+  override def removed(key: String): Map[String, String] = new Headers(mapWithLowerCaseKeys - key.toLowerCase)
 
   override def contains(key: String): Boolean = mapWithLowerCaseKeys.contains(key.toLowerCase())
 

--- a/src/main/scala/uzhttp/server/Request.scala
+++ b/src/main/scala/uzhttp/server/Request.scala
@@ -101,13 +101,13 @@ object Request {
   }
 
   private[server] object NoBody {
-    def fromReqString(str: String): Either[BadRequest, NoBody] = str.lines.dropWhile(_.isEmpty).toList match {
+    def fromReqString(str: String): Either[BadRequest, NoBody] = str.linesWithSeparators.map(_.stripLineEnd).dropWhile(_.isEmpty).toList match {
       case Nil => Left(BadRequest("Empty request"))
       case first :: rest =>
         first.split(' ').toList match {
           case List(methodStr, uri, versionStr) => for {
-            method  <- Method.parseEither(methodStr).right
-            version <- Version.parseEither(versionStr).right
+            method  <- Method.parseEither(methodStr)
+            version <- Version.parseEither(versionStr)
           } yield NoBody(method, uri, version, Headers.fromLines(rest))
         }
     }

--- a/src/main/scala/uzhttp/server/Server.scala
+++ b/src/main/scala/uzhttp/server/Server.scala
@@ -504,7 +504,7 @@ object Server {
     }
 
     def close(): URIO[Logging, Unit] =
-      ZIO.foreach(selector.keys().asScala)(k => effect(k.cancel())).orDie *> effect(selector.close()).orDie *>
+      ZIO.foreach(selector.keys().toIterable)(k => effect(k.cancel())).orDie *> effect(selector.close()).orDie *>
         effect(serverSocket.close()).orDie
 
     def run: RIO[Logging with Blocking with Clock, Nothing] = (select *> ZIO.yieldNow).forever

--- a/src/main/scala/uzhttp/server/package.scala
+++ b/src/main/scala/uzhttp/server/package.scala
@@ -1,5 +1,7 @@
 package uzhttp
 
+import java.nio.channels.SelectionKey
+
 package object server {
   val CRLF: Array[Byte] = Array('\r', '\n')
   val EmptyLine: Array[Byte] = CRLF ++ CRLF
@@ -8,7 +10,7 @@ package object server {
   private[server] def humanReadableByteCountSI(bytes: Long): String = {
     val s = if (bytes < 0) "-" else ""
     var b = if (bytes == Long.MinValue) Long.MaxValue else Math.abs(bytes)
-    if (b < 1000L) return bytes + " B"
+    if (b < 1000L) return bytes.toString + " B"
     if (b < 999950L) return "%s%.1f kB".format(s, b / 1e3)
     b /= 1000
     if (b < 999950L) return "%s%.1f MB".format(s, b / 1e3)
@@ -17,5 +19,29 @@ package object server {
     b /= 1000
 
     "%s%.1f TB".format(s, b / 1e3)
+  }
+
+  private[server] implicit class IterateKeys(val self: java.util.Set[SelectionKey]) extends AnyVal {
+    def toIterable: Iterable[SelectionKey] = new Iterable[SelectionKey] {
+      override def iterator: Iterator[SelectionKey] = {
+        val jIterator = self.iterator()
+        new Iterator[SelectionKey] {
+          override def hasNext: Boolean = jIterator.hasNext
+          override def next(): SelectionKey = jIterator.next()
+        }
+      }
+    }
+  }
+
+  private[server] implicit class EitherCompat[+L, +R](val self: Either[L, R]) extends AnyVal {
+    def flatMap[L1 >: L, R1](fn: R => Either[L1, R1]): Either[L1, R1] = self match {
+      case Left(l)  => Left(l)
+      case Right(r) => fn(r)
+    }
+
+    def map[R1](fn: R => R1): Either[L, R1] = self match {
+      case Left(l) => Left(l)
+      case Right(r) => Right(fn(r))
+    }
   }
 }

--- a/src/test/scala/uzhttp/server/ResponseSpec.scala
+++ b/src/test/scala/uzhttp/server/ResponseSpec.scala
@@ -28,7 +28,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
   private def splitRequest(req: Chunk[Byte]) = {
     val arr = req.toArray
     val splitPoint = arr.indexOfSlice(Seq('\r', '\n', '\r', '\n'))
-    val headerLines = new String(arr, 0, splitPoint, StandardCharsets.US_ASCII).lines.toList
+    val headerLines = new String(arr, 0, splitPoint, StandardCharsets.US_ASCII).linesWithSeparators.map(_.stripLineEnd).toList
     (headerLines.head, Headers.fromLines(headerLines.tail), req.drop(splitPoint + 4))
   }
 

--- a/src/test/scala/uzhttp/server/ResponseSpec.scala
+++ b/src/test/scala/uzhttp/server/ResponseSpec.scala
@@ -153,6 +153,8 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
         stream.close()
       }
 
+      jarFile.toFile.deleteOnExit()
+
       val jarModified = Files.getLastModifiedTime(jarFile).toInstant
       val cl = new URLClassLoader(Array(jarFile.toUri.toURL), null)
 

--- a/src/test/scala/uzhttp/server/ResponseSpec.scala
+++ b/src/test/scala/uzhttp/server/ResponseSpec.scala
@@ -44,6 +44,8 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
   }
 
   private def timeStr(inst: Instant): String = DateTimeFormatter.RFC_1123_DATE_TIME.format(inst.atZone(ZoneOffset.UTC))
+  private def parseTime(str: String): Instant = DateTimeFormatter.RFC_1123_DATE_TIME.parse(str, toInstant)
+  private def trunc(inst: Instant): Instant = parseTime(timeStr(inst))
   private val currentTimeStr: String = timeStr(Instant.now())
 
   "Constant response" - {
@@ -73,7 +75,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
           headers("Flerg") mustEqual "Blerg"
           headers("Content-Length") mustEqual expected.length.toString
           headers("Content-Type") mustEqual "text/plain"
-          DateTimeFormatter.RFC_1123_DATE_TIME.parse(headers("Modified"), toInstant) mustEqual modified
+          parseTime(headers("Modified")) mustEqual trunc(modified)
           body.toArray must contain theSameElementsInOrderAs expected
       }
     }
@@ -114,7 +116,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
             headers("Flerg") mustEqual "Blerg"
             headers("Content-Length") mustEqual expected.length.toString
             headers("Content-Type") mustEqual "text/plain"
-            DateTimeFormatter.RFC_1123_DATE_TIME.parse(headers("Modified"), toInstant) mustEqual modified
+            parseTime(headers("Modified")) mustEqual trunc(modified)
             body.toArray must contain theSameElementsInOrderAs expected
         }
       }
@@ -161,7 +163,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
             headers("Flerg") mustEqual "Blerg"
             headers("Content-Length") mustEqual expected.length.toString
             headers("Content-Type") mustEqual "text/plain"
-            DateTimeFormatter.RFC_1123_DATE_TIME.parse(headers("Modified"), toInstant) mustEqual jarModified
+            parseTime(headers("Modified")) mustEqual trunc(jarModified)
             body.toArray must contain theSameElementsInOrderAs expected
         }
       }

--- a/src/test/scala/uzhttp/server/ServerSpec.scala
+++ b/src/test/scala/uzhttp/server/ServerSpec.scala
@@ -7,7 +7,7 @@ import zio.stream.{Sink, Stream, Take}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import sttp.client._
+import sttp.client.{Response => _, _}
 import sttp.client.asynchttpclient.WebSocketHandler
 import sttp.client.asynchttpclient.zio._
 import sttp.model.ws.WebSocketFrame


### PR DESCRIPTION
Builds upon #1 to enable cross-build on Scala 2.13

- Add a custom decorator for `Set` to avoid clashing Java collection converter needs
- Add a decorator for `Either` to get right-bias in 2.11
- Add a small compatibility layer for implementing `Map` the same way across versions (probably should have just not extended `Map`, it's always folly to do so... oh well)