### PR TITLE
Use URI to represent URI

### DIFF
--- a/src/main/scala/uzhttp/Response.scala
+++ b/src/main/scala/uzhttp/Response.scala
@@ -90,7 +90,7 @@ object Response {
     *         catch these and convert them to [[HTTPError]] failures.
     */
   def fromPath(path: Path, request: Request, contentType: String = "application/octet-stream", status: Status = Status.Ok, headers: List[(String, String)] = Nil): ZIO[Blocking, Throwable, Response] =
-    checkExists(path, request.uri) *> checkModifiedSince(path, request.headers.get("If-Modified-Since")) orElse {
+    checkExists(path, request.uri.toString) *> checkModifiedSince(path, request.headers.get("If-Modified-Since")) orElse {
       for {
         size     <- effectBlocking(path.toFile.length())
         modified <- getModifiedTime(path).map(formatInstant).option
@@ -126,10 +126,10 @@ object Response {
     status: Status = Status.Ok,
     headers: List[(String, String)] = Nil
   ): ZIO[Blocking, Throwable, Response] = effectBlocking(Option(classLoader.getResource(name)))
-    .someOrFail(NotFound(request.uri))
+    .someOrFail(NotFound(request.uri.toString))
     .flatMap {
       resource =>
-        localPath(resource.toURI).get.tap(checkExists(_, request.uri)).flatMap(path => checkModifiedSince(path, request.headers.get("If-Modified-Since"))) orElse {
+        localPath(resource.toURI).get.tap(checkExists(_, request.uri.toString)).flatMap(path => checkModifiedSince(path, request.headers.get("If-Modified-Since"))) orElse {
           resource match {
             case url if url.getProtocol == "file" =>
               for {

--- a/src/main/scala/uzhttp/Response.scala
+++ b/src/main/scala/uzhttp/Response.scala
@@ -90,7 +90,7 @@ object Response {
     *         catch these and convert them to [[HTTPError]] failures.
     */
   def fromPath(path: Path, request: Request, contentType: String = "application/octet-stream", status: Status = Status.Ok, headers: List[(String, String)] = Nil): ZIO[Blocking, Throwable, Response] =
-    checkExists(path, request.uri.toString) *> checkModifiedSince(path, request.headers.get("If-Modified-Since")) orElse {
+    checkExists(path, request.uri.toString) *> checkModifiedSince(path, request.headers.get("If-Modified-Since")).orElse {
       for {
         size     <- effectBlocking(path.toFile.length())
         modified <- getModifiedTime(path).map(formatInstant).option
@@ -225,7 +225,8 @@ object Response {
 
     override private[uzhttp] def writeTo(connection: Server.ConnectionWriter): ZIO[Blocking, Throwable, Unit] = {
       effectBlocking(FileChannel.open(path, StandardOpenOption.READ)).toManaged(chan => effectTotal(chan.close())).use {
-        chan => connection.transferFrom(ByteBuffer.wrap(Response.headerBytes(this)), chan)
+        chan =>
+          connection.transferFrom(ByteBuffer.wrap(Response.headerBytes(this)), chan)
       }
 
     }

--- a/src/main/scala/uzhttp/server/Server.scala
+++ b/src/main/scala/uzhttp/server/Server.scala
@@ -388,7 +388,8 @@ object Server {
                     _             <- handleRequest(request).forkDaemon
                   } yield ()
 
-                case request => handleRequest(request).forkDaemon
+                case request =>
+                  handleRequest(request).forkDaemon
               }
 
               mkReq *> bytesReceived(remainderLength)

--- a/src/main/scala/uzhttp/server/Server.scala
+++ b/src/main/scala/uzhttp/server/Server.scala
@@ -521,7 +521,7 @@ object Server {
   }
 
   private val unhandled: PartialFunction[Request, ZIO[Any, HTTPError, Nothing]] = {
-    case req => ZIO.fail(NotFound(req.uri))
+    case req => ZIO.fail(NotFound(req.uri.toString))
   }
 
   private val defaultErrorFormatter: HTTPError => ZIO[Any, Nothing, Response] =

--- a/src/test/scala/uzhttp/server/ResponseSpec.scala
+++ b/src/test/scala/uzhttp/server/ResponseSpec.scala
@@ -1,7 +1,7 @@
 package uzhttp.server
 
 import java.io.{FileOutputStream, InputStream}
-import java.net.URLClassLoader
+import java.net.{URI, URLClassLoader}
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
@@ -67,7 +67,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
     val modified = Files.getLastModifiedTime(path).toInstant
     val expected = Files.readAllBytes(path)
 
-    val req = Request.NoBody(Request.Method.GET, "/path-test.txt", Version.Http11, Headers.empty)
+    val req = Request.NoBody(Request.Method.GET, new URI("/path-test.txt"), Version.Http11, Headers.empty)
 
     "writes to connection" in {
       verify(unsafeRun(Response.fromPath(path, req, contentType = "text/plain", headers = List("Flerg" -> "Blerg")))) {
@@ -107,7 +107,7 @@ class ResponseSpec extends AnyFreeSpec with Matchers {
     val path = Paths.get(getClass.getClassLoader.getResource(resource).toURI)
     val modified = Files.getLastModifiedTime(path).toInstant
     val expected = Files.readAllBytes(path)
-    val req = Request.NoBody(Request.Method.GET, "/path-test.txt", Version.Http11, Headers.empty)
+    val req = Request.NoBody(Request.Method.GET, new URI("/path-test.txt"), Version.Http11, Headers.empty)
 
     "when resource is un-jarred" - {
       "writes to connection" in {

--- a/src/test/scala/uzhttp/server/ServerSpec.scala
+++ b/src/test/scala/uzhttp/server/ServerSpec.scala
@@ -41,7 +41,7 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
                       Chunk.fromIterable(bytes).flatten.toArray,
                       headers = req.headers.toList.map {
                         case (name, value) => s"x-echoed-$name" -> value
-                      } ++ List("x-echoed-request-uri" -> req.uri, "x-echoed-method" -> req.method.name, "Content-Type" -> "application/octet-stream")
+                      } ++ List("x-echoed-request-uri" -> req.uri.toString, "x-echoed-method" -> req.method.name, "Content-Type" -> "application/octet-stream")
                     )
                 }
               case None =>
@@ -53,7 +53,7 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
                 s"${req.method.name} ${req.uri} HTTP/${req.version.string}\r\n${req.headers.toList.map { case (k,v) => s"$k: $v" }.mkString("\r\n")}",
                 headers = req.headers.toList.map {
                   case (name, value) => s"x-echoed-$name" -> value
-                } ++ List("x-echoed-request-uri" -> req.uri, "x-echoed-method" -> req.method.name)
+                } ++ List("x-echoed-request-uri" -> req.uri.toString, "x-echoed-method" -> req.method.name)
               )
             }
           }
@@ -108,6 +108,19 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
                 rep.body must contain theSameElementsInOrderAs body
               }
             }
+          }
+        }
+      }
+    }
+
+    "Decodes URI" in {
+      unsafeRun {
+        basicRequest.get(uri"http://localhost:$port/basic%20request?foo=hey%20hello").send().flatMap {
+          rep => ZIO.effect {
+            rep.code.code mustEqual 200
+            val headers = rep.headers.map(h => h.name.toLowerCase -> h.value).toMap
+            headers("x-echoed-request-uri") mustEqual "/basicReq"
+            headers("x-echoed-method") mustEqual "GET"
           }
         }
       }

--- a/src/test/scala/uzhttp/server/ServerSpec.scala
+++ b/src/test/scala/uzhttp/server/ServerSpec.scala
@@ -41,7 +41,7 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
                       Chunk.fromIterable(bytes).flatten.toArray,
                       headers = req.headers.toList.map {
                         case (name, value) => s"x-echoed-$name" -> value
-                      } ++ List("x-echoed-request-uri" -> req.uri.toString, "x-echoed-method" -> req.method.name, "Content-Type" -> "application/octet-stream")
+                      } ++ List("x-echoed-request-uri" -> req.uri.getPath, "x-echoed-method" -> req.method.name, "Content-Type" -> "application/octet-stream")
                     )
                 }
               case None =>
@@ -53,7 +53,7 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
                 s"${req.method.name} ${req.uri} HTTP/${req.version.string}\r\n${req.headers.toList.map { case (k,v) => s"$k: $v" }.mkString("\r\n")}",
                 headers = req.headers.toList.map {
                   case (name, value) => s"x-echoed-$name" -> value
-                } ++ List("x-echoed-request-uri" -> req.uri.toString, "x-echoed-method" -> req.method.name)
+                } ++ List("x-echoed-request-uri" -> req.uri.getPath, "x-echoed-method" -> req.method.name)
               )
             }
           }
@@ -115,11 +115,11 @@ class ServerSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
 
     "Decodes URI" in {
       unsafeRun {
-        basicRequest.get(uri"http://localhost:$port/basic%20request?foo=hey%20hello").send().flatMap {
+        basicRequest.get(uri"http://localhost:$port/basic%20request").send().flatMap {
           rep => ZIO.effect {
             rep.code.code mustEqual 200
             val headers = rep.headers.map(h => h.name.toLowerCase -> h.value).toMap
-            headers("x-echoed-request-uri") mustEqual "/basicReq"
+            headers("x-echoed-request-uri") mustEqual "/basic request"
             headers("x-echoed-method") mustEqual "GET"
           }
         }

--- a/src/test/scala/uzhttp/server/TestServer.scala
+++ b/src/test/scala/uzhttp/server/TestServer.scala
@@ -31,7 +31,7 @@ object TestServer extends zio.App {
   }
 
   private def servePath(req: Request): ZIO[Blocking, Throwable, Response] =
-    Response.fromPath(resourcePath.resolve(uri(req) stripPrefix "/"), req, contentType = contentType(uri(req)))
+    Response.fromPath(resourcePath.resolve(uri(req).stripPrefix("/")), req, contentType = contentType(uri(req)))
 
   private def serveResource(req: Request): ZIO[Blocking, Throwable, Response] =
     Response.fromResource(s"site${uri(req)}", req, contentType = contentType(uri(req)))

--- a/src/test/scala/uzhttp/server/TestServer.scala
+++ b/src/test/scala/uzhttp/server/TestServer.scala
@@ -25,13 +25,13 @@ object TestServer extends zio.App {
       case err => ZIO.fail(HTTPError.InternalServerError(err.getMessage))
     })
 
-  private def uri(req: Request) = req.uri match {
+  private def uri(req: Request) = req.uri.toString match {
     case "/" | "" => "/index.html"
     case uri => uri
   }
 
   private def servePath(req: Request): ZIO[Blocking, Throwable, Response] =
-    Response.fromPath(resourcePath.resolve(uri(req)stripPrefix("/")), req, contentType = contentType(uri(req)))
+    Response.fromPath(resourcePath.resolve(uri(req) stripPrefix "/"), req, contentType = contentType(uri(req)))
 
   private def serveResource(req: Request): ZIO[Blocking, Throwable, Response] =
     Response.fromResource(s"site${uri(req)}", req, contentType = contentType(uri(req)))


### PR DESCRIPTION
Can't just use String URIs, because there is all kinds of decoding that goes into different places. Can't just decode it once, because decoding is lossy.

Instead, just represent URIs as URIs and the user can do what they will.