### PR TITLE
Add idle timeout, perf enhancements, caching fixes & utils

### DIFF
--- a/src/main/scala/uzhttp/header/Headers.scala
+++ b/src/main/scala/uzhttp/header/Headers.scala
@@ -12,7 +12,7 @@ final class Headers private (private val mapWithLowerCaseKeys: Map[String, (Stri
   override def iterator: Iterator[(String, String)] = mapWithLowerCaseKeys.iterator.map {
     case (_, origKeyWithValue) => origKeyWithValue
   }
-  override def removed(key: String): Map[String, String] = new Headers(mapWithLowerCaseKeys - key.toLowerCase)
+  override def removed(key: String): Headers = new Headers(mapWithLowerCaseKeys - key.toLowerCase)
 
   override def contains(key: String): Boolean = mapWithLowerCaseKeys.contains(key.toLowerCase())
 
@@ -20,6 +20,11 @@ final class Headers private (private val mapWithLowerCaseKeys: Map[String, (Stri
 
   def ++(kvs: Seq[(String, String)]): Headers = new Headers(mapWithLowerCaseKeys ++ ListMap(kvs.map(kv => kv._1.toLowerCase -> (kv._1 -> kv._2)): _*))
   def ++(headers: Headers): Headers = new Headers(mapWithLowerCaseKeys ++ headers.mapWithLowerCaseKeys)
+
+  def +?(kv: (String, Option[String])): Headers = kv match {
+    case (key, Some(v)) => this + (key -> v)
+    case (_, None)      => this
+  }
 }
 
 object Headers {

--- a/src/main/scala/uzhttp/header/Headers.scala
+++ b/src/main/scala/uzhttp/header/Headers.scala
@@ -43,4 +43,10 @@ object Headers {
   implicit def fromSeq(kvs: Seq[(String, String)]): Headers = apply(kvs: _*)
 
   val empty: Headers = apply()
+
+  val CacheControl: String = "Cache-Control"
+  val ContentLength: String = "Content-Length"
+  val ContentType: String = "Content-Type"
+  val IfModifiedSince: String = "If-Modified-Since"
+  val LastModified: String = "Last-Modified"
 }

--- a/src/main/scala/uzhttp/package.scala
+++ b/src/main/scala/uzhttp/package.scala
@@ -1,3 +1,5 @@
+import java.net.URI
+
 package object uzhttp {
 
 

--- a/src/main/scala/uzhttp/server/ServerLogger.scala
+++ b/src/main/scala/uzhttp/server/ServerLogger.scala
@@ -27,13 +27,14 @@ object ServerLogger {
     effectTotal(System.err.println(s"[REQUEST] ${req.uri} ${rep.status} ($finishTime to finish, $totalTime total) $closedTag"))
   }
 
-  val defaultInfoLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[INFO]   $str"))
-  val defaultErrorLogger: (String, Throwable) => UIO[Unit] = (str, err) => effectTotal { System.err.println(s"[ERROR]  $str"); err.printStackTrace(System.err) }
+  val defaultInfoLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[INFO]    $str"))
+  val defaultErrorLogger: (String, Throwable) => UIO[Unit] = (str, err) => effectTotal { System.err.println(s"[ERROR]   $str"); err.printStackTrace(System.err) }
+  val defaultDebugLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[DEBUG]   $str"))
   val noLog: (=> String) => UIO[Unit] = _ => ZIO.unit
   val noLogRequests: (Request, Response, Duration, Duration) => UIO[Unit] = (_, _, _, _) => ZIO.unit
 
   lazy val Default: ServerLogger[Any] = ServerLogger(defaultInfoLogger, defaultRequestLogger, defaultErrorLogger, noLog)
-  lazy val Debug: ServerLogger[Any] = Default.copy(debug = str => effectTotal(System.err.println(s"[DEBUG]  $str")))
+  lazy val Debug: ServerLogger[Any] = Default.copy(debug = defaultDebugLogger)
   lazy val Quiet: ServerLogger[Any] = Default.copy(info = noLog, request = noLogRequests)
   lazy val Silent: ServerLogger[Any] = Quiet.copy(error = (_, _) => ZIO.unit)
 }

--- a/src/test/scala/uzhttp/server/MockConnectionWriter.scala
+++ b/src/test/scala/uzhttp/server/MockConnectionWriter.scala
@@ -11,6 +11,7 @@ import zio.{Chunk, Ref, Task, ZIO, stream}
 import TestRuntime.runtime.unsafeRun
 
 case class MockConnectionWriter(writtenBytes: Ref[Chunk[Byte]] = unsafeRun(Ref.make(Chunk.empty))) extends Server.ConnectionWriter {
+  override def write(bytes: ByteBuffer): Task[Unit] = writtenBytes.update(_ ++ Chunk.fromByteBuffer(bytes))
   override def write(bytes: Array[Byte]): Task[Unit] = writtenBytes.update(_ ++ Chunk.fromArray(bytes))
   override def writeByteBuffers(buffers: stream.Stream[Throwable, ByteBuffer]): Task[Unit] = buffers.foreach {
     buf => writtenBytes.update(_ ++ Chunk.fromByteBuffer(buf))

--- a/src/test/scala/uzhttp/server/MockConnectionWriter.scala
+++ b/src/test/scala/uzhttp/server/MockConnectionWriter.scala
@@ -1,49 +1,22 @@
 package uzhttp.server
 
-import java.io.InputStream
 import java.nio.ByteBuffer
-import java.nio.channels.FileChannel
+import java.nio.channels.WritableByteChannel
 
-import zio.ZIO.effect
-import zio.blocking.Blocking
-import zio.{Chunk, Ref, Task, ZIO, stream}
-
+import zio.{Chunk, RIO, Ref, Semaphore}
 import TestRuntime.runtime.unsafeRun
 
 case class MockConnectionWriter(writtenBytes: Ref[Chunk[Byte]] = unsafeRun(Ref.make(Chunk.empty))) extends Server.ConnectionWriter {
-  override def write(bytes: ByteBuffer): Task[Unit] = writtenBytes.update(_ ++ Chunk.fromByteBuffer(bytes))
-  override def write(bytes: Array[Byte]): Task[Unit] = writtenBytes.update(_ ++ Chunk.fromArray(bytes))
-  override def writeByteBuffers(buffers: stream.Stream[Throwable, ByteBuffer]): Task[Unit] = buffers.foreach {
-    buf => writtenBytes.update(_ ++ Chunk.fromByteBuffer(buf))
-  }
-  override def writeByteArrays(arrays: stream.Stream[Throwable, Array[Byte]]): Task[Unit] = arrays.foreach {
-    arr => writtenBytes.update(_ ++ Chunk.fromArray(arr))
-  }
-  override def transferFrom(header: ByteBuffer, src: FileChannel): ZIO[Blocking, Throwable, Unit] = {
-    val buf = ByteBuffer.allocate(1024)
-    writtenBytes.update(_ ++ Chunk.fromByteBuffer(header)) *> effect {
-      buf.rewind()
-      val read = src.read(buf)
-      if (read > 0) {
-        val slice = buf.duplicate()
-        slice.rewind()
-        slice.limit(read)
-        (read, Chunk.fromByteBuffer(slice))
-      } else (read, Chunk.empty)
-    }.doUntil(t => t._1 < 0 || t._2.nonEmpty).flatMap {
-      case (read, chunk) => writtenBytes.update(_ ++ chunk).as(read)
-    }.doUntil(_ < 0).unit
+  private val writeLock: Semaphore = unsafeRun(Semaphore.make(1L))
+  private val channel = new WritableByteChannel {
+    override def write(src: ByteBuffer): Int = if (src.hasRemaining) {
+      val chunk = Chunk.fromByteBuffer(src)
+      src.position(src.position() + chunk.size)
+      unsafeRun(writtenBytes.update(_ ++ chunk).as(chunk.size))
+    } else 0
+    override def isOpen: Boolean = true
+    override def close(): Unit = ()
   }
 
-  override def pipeFrom(header: ByteBuffer, is: InputStream, bufSize: Int): ZIO[Blocking, Throwable, Unit] = {
-    val buf = new Array[Byte](1024)
-    writtenBytes.update(_ ++ Chunk.fromByteBuffer(header)) *> effect {
-      val read = is.read(buf)
-      if (read > 0) {
-        (read, Chunk.fromArray(java.util.Arrays.copyOf(buf, read)))
-      } else (read, Chunk.empty)
-    }.doUntil(t => t._1 < 0 || t._2.nonEmpty).flatMap {
-      case (read, chunk) => writtenBytes.update(_ ++ chunk).as(read)
-    }.doUntil(_ < 0).unit
-  }
+  override def withWriteLock[R](fn: WritableByteChannel => RIO[R, Unit]): RIO[R, Unit] = writeLock.withPermit(fn(channel))
 }


### PR DESCRIPTION
- Add configuration for idle timeout of requests, fix idle timeout implementation
- Fix incorrect headers for caching (`Last-Modified` instead of `Modified`)
- Add method for setting typical `Cache-Control` header to use cache revalidation
- Add `Response.cache` builder for creating an in-memory response cache
- Add memory-mapped path response