### PR TITLE
Log request method

### DIFF
--- a/src/main/scala/uzhttp/server/ServerLogger.scala
+++ b/src/main/scala/uzhttp/server/ServerLogger.scala
@@ -24,7 +24,7 @@ object ServerLogger {
     val closedTag = if (rep.closeAfter) "(closed)" else "(keepalive)"
     val finishTime = finishDuration.render
     val totalTime = (startDuration + finishDuration).render
-    effectTotal(System.err.println(s"[REQUEST] ${req.uri} ${rep.status} ($finishTime to finish, $totalTime total) $closedTag"))
+    effectTotal(System.err.println(s"[REQUEST] ${req.method.name} ${req.uri} ${rep.status} ($finishTime to finish, $totalTime total) $closedTag"))
   }
 
   val defaultInfoLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[INFO]    $str"))


### PR DESCRIPTION
Tiny addition to add the method to the default request logger. I think it's super useful.

Before:
`[REQUEST] /basicReq 200 OK (2 ms to finish, 38 ms total) (keepalive)`
After:
`[REQUEST] GET /basicReq 200 OK (2 ms to finish, 38 ms total) (keepalive)`