### PR TITLE
Fix a blocking issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 organization := "org.polynote"
 name := "uzhttp"
-version := "0.1.1"
+version := "0.1.2-SNAPSHOT"
 scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 

--- a/src/main/scala/uzhttp/Request.scala
+++ b/src/main/scala/uzhttp/Request.scala
@@ -24,6 +24,7 @@ trait Request {
 
 trait ContinuingRequest extends Request {
   def submitBytes(chunk: Chunk[Byte]): UIO[Unit]
+  def channelClosed(): UIO[Unit]
   def bytesRemaining: UIO[Long]
   def noBufferInput: Boolean
 }
@@ -63,6 +64,7 @@ object Request {
     override def addHeader(name: String, value: String): Request = copy(headers = headers + (name -> value))
     override def removeHeader(name: String): Request = copy(headers = headers.removed(name))
     override def bytesRemaining: UIO[Long] = received.get.map(contentLength - _)
+    override def channelClosed(): UIO[Unit] = ZIO.unit
     override def submitBytes(chunk: Chunk[Byte]): UIO[Unit] = bodyQueue.offer(Take.Value(chunk)) *> received.updateAndGet(_ + chunk.length).flatMap {
       case received if received >= contentLength => bodyQueue.offer(Take.End).unit
       case _ => ZIO.unit
@@ -118,6 +120,7 @@ object Request {
     override val body: Option[StreamChunk[HTTPError, Byte]] = None
     override val bytesRemaining: UIO[Long] = ZIO.succeed(Long.MaxValue)
     override def submitBytes(chunk: Chunk[Byte]): UIO[Unit] = chunks.offer(Take.Value(chunk)).unit
+    override def channelClosed(): UIO[Unit] = chunks.offer(Take.End).unit
     override val noBufferInput: Boolean = true
     lazy val frames: Stream[Throwable, Frame] = Frame.parse(ZStream.fromQueueWithShutdown(chunks).unTake)
   }

--- a/src/main/scala/uzhttp/server/Server.scala
+++ b/src/main/scala/uzhttp/server/Server.scala
@@ -196,7 +196,7 @@ object Server {
   }
 
   private[uzhttp] trait ConnectionWriter {
-    def withWriteLock[R](fn: WritableByteChannel => RIO[R, Unit]): RIO[R, Unit]
+    def withWriteLock[R, E](fn: WritableByteChannel => ZIO[R, E, Unit]): ZIO[R, E, Unit]
     private def writeInternal(channel: WritableByteChannel, bytes: ByteBuffer): Task[Unit] = effect(channel.write(bytes)).as(bytes).doWhile(_.hasRemaining).unit
     def write(bytes: ByteBuffer): Task[Unit] = withWriteLock(channel => writeInternal(channel, bytes))
     def write(bytes: Array[Byte]): Task[Unit] = write(ByteBuffer.wrap(bytes))
@@ -249,7 +249,7 @@ object Server {
 
     final class TappedWriter(underlying: ConnectionWriter) extends ConnectionWriter {
       private val tappedChannel = new TappedChannel()
-      override def withWriteLock[R](fn: WritableByteChannel => RIO[R, Unit]): RIO[R, Unit] = underlying.withWriteLock {
+      override def withWriteLock[R, E](fn: WritableByteChannel => ZIO[R, E, Unit]): ZIO[R, E, Unit] = underlying.withWriteLock {
         underlyingChannel =>
           tappedChannel.underlying.set(underlyingChannel)
           fn(tappedChannel)
@@ -273,7 +273,7 @@ object Server {
     import config._
     import locks._
 
-    override def withWriteLock[R](fn: WritableByteChannel => RIO[R, Unit]): RIO[R, Unit] = writeLock.withPermit(fn(channel))
+    override def withWriteLock[R, E](fn: WritableByteChannel => ZIO[R, E, Unit]): ZIO[R, E, Unit] = writeLock.withPermit(fn(channel))
 
     /**
       * Take n bytes from the top of the input buffer, and shift the remaining bytes (up to the buffer's position), if
@@ -444,19 +444,21 @@ object Server {
       }
     }
 
-    def close(): URIO[Logging, Unit] = writeLock.withPermit {
+    private def endCurrentRequest = curReq.get.flatMap {
+      case Right(req) => req.channelClosed()
+      case _ => ZIO.unit
+    }
+
+    def close(): URIO[Logging, Unit] =
       shutdown.succeed(()).flatMap {
         case true  =>
           Logging.debug(s"Closing connection") *>
-            effect(channel.close()).orDie *>
+            endCurrentRequest *>
             stopIdleTimeout *>
-            curReq.get.flatMap {
-              case Right(req) => req.channelClosed()
-              case _ => ZIO.unit
-            }
+            withWriteLock(channel => effectTotal(channel.close()))
+
         case false => ZIO.unit
       }
-    }
 
     val awaitShutdown: IO[Throwable, Unit] = shutdown.await
 

--- a/src/test/scala/uzhttp/server/MockConnectionWriter.scala
+++ b/src/test/scala/uzhttp/server/MockConnectionWriter.scala
@@ -3,7 +3,7 @@ package uzhttp.server
 import java.nio.ByteBuffer
 import java.nio.channels.WritableByteChannel
 
-import zio.{Chunk, RIO, Ref, Semaphore}
+import zio.{Chunk, RIO, Ref, Semaphore, ZIO}
 import TestRuntime.runtime.unsafeRun
 
 case class MockConnectionWriter(writtenBytes: Ref[Chunk[Byte]] = unsafeRun(Ref.make(Chunk.empty))) extends Server.ConnectionWriter {
@@ -18,5 +18,5 @@ case class MockConnectionWriter(writtenBytes: Ref[Chunk[Byte]] = unsafeRun(Ref.m
     override def close(): Unit = ()
   }
 
-  override def withWriteLock[R](fn: WritableByteChannel => RIO[R, Unit]): RIO[R, Unit] = writeLock.withPermit(fn(channel))
+  override def withWriteLock[R, E](fn: WritableByteChannel => ZIO[R, E, Unit]): ZIO[R, E, Unit] = writeLock.withPermit(fn(channel))
 }


### PR DESCRIPTION
Fixes an issue where the selector code assumed that the server channel did non-blocking selects, but it didn't

Also fixes an issue (I hope) where interruption in user's websocket code can cause the whole selector loop to get interrupted.