### PR TITLE
More log "levels" for peace and quiet; ensure connection close on write error

### DIFF
--- a/src/main/scala/uzhttp/server/Server.scala
+++ b/src/main/scala/uzhttp/server/Server.scala
@@ -162,6 +162,9 @@ object Server {
     def logDebug[R1 <: R](debugLogger: (=> String) => URIO[R1, Unit]): Builder[R1] =
       copy(logger = logger.copy(debug = debugLogger))
 
+    def logDebugErrors[R1 <: R](debugErrorLogger: (String, Throwable) => URIO[R1, Unit]): Builder[R1] =
+      copy(logger = logger.copy(debugError = debugErrorLogger))
+
     private def build: ZManaged[R with Blocking with Logging, Throwable, Server] =
       mkSocket(address, config.maxPending)
         .flatMap {

--- a/src/main/scala/uzhttp/server/ServerLogger.scala
+++ b/src/main/scala/uzhttp/server/ServerLogger.scala
@@ -32,13 +32,13 @@ object ServerLogger {
   val defaultInfoLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[INFO]    $str"))
   val defaultErrorLogger: (String, Throwable) => UIO[Unit] = (str, err) => effectTotal { System.err.println(s"[ERROR]   $str"); err.printStackTrace(System.err) }
   val defaultDebugLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[DEBUG]   $str"))
-  val defaultDebugLogger: (String, Throwable) => ZIO[Any, Nothing, Unit] = (str, err) => effectTotal { System.err.println(s"[DEBUG]   $str"); err.printStackTrace(System.err) }
+  val defaultDebugErrorLogger: (String, Throwable) => ZIO[Any, Nothing, Unit] = (str, err) => effectTotal { System.err.println(s"[DEBUG]   $str"); err.printStackTrace(System.err) }
   val noLog: (=> String) => UIO[Unit] = _ => ZIO.unit
   val noLogRequests: (Request, Response, Duration, Duration) => UIO[Unit] = (_, _, _, _) => ZIO.unit
   val noLogErrors: (String, Throwable) => ZIO[Any, Nothing, Unit] = (_, _) => ZIO.unit
 
   lazy val Default: ServerLogger[Any] = ServerLogger(defaultInfoLogger, defaultRequestLogger, defaultErrorLogger, noLogErrors, noLog)
-  lazy val Debug: ServerLogger[Any] = Default.copy(debug = defaultDebugLogger, )
+  lazy val Debug: ServerLogger[Any] = Default.copy(debug = defaultDebugLogger, debugError = defaultDebugErrorLogger)
   lazy val Quiet: ServerLogger[Any] = Default.copy(info = noLog, request = noLogRequests)
   lazy val Silent: ServerLogger[Any] = Quiet.copy(error = noLogErrors)
 }

--- a/src/main/scala/uzhttp/server/ServerLogger.scala
+++ b/src/main/scala/uzhttp/server/ServerLogger.scala
@@ -9,12 +9,14 @@ case class ServerLogger[-R](
   info: (=> String) => ZIO[R, Nothing, Unit],
   request: (Request, Response, Duration, Duration) => ZIO[R, Nothing, Unit],
   error: (String, Throwable) => ZIO[R, Nothing, Unit],
+  debugError: (String, Throwable) => ZIO[R, Nothing, Unit],
   debug: (=> String) => ZIO[R, Nothing, Unit] = ServerLogger.noLog
 ) {
   def provide(R: R): ServerLogger[Any] = copy(
     info = info andThen (_.provide(R)),
     request = (req, rep, sd, fd) => request(req, rep, sd, fd).provide(R),
     error = (msg, err) => error(msg, err).provide(R),
+    debugError = (msg, err) => debugError(msg, err).provide(R),
     debug = debug andThen (_.provide(R))
   )
 }
@@ -30,11 +32,13 @@ object ServerLogger {
   val defaultInfoLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[INFO]    $str"))
   val defaultErrorLogger: (String, Throwable) => UIO[Unit] = (str, err) => effectTotal { System.err.println(s"[ERROR]   $str"); err.printStackTrace(System.err) }
   val defaultDebugLogger: (=> String) => UIO[Unit] = str => effectTotal(System.err.println(s"[DEBUG]   $str"))
+  val defaultDebugLogger: (String, Throwable) => ZIO[Any, Nothing, Unit] = (str, err) => effectTotal { System.err.println(s"[DEBUG]   $str"); err.printStackTrace(System.err) }
   val noLog: (=> String) => UIO[Unit] = _ => ZIO.unit
   val noLogRequests: (Request, Response, Duration, Duration) => UIO[Unit] = (_, _, _, _) => ZIO.unit
+  val noLogErrors: (String, Throwable) => ZIO[Any, Nothing, Unit] = (_, _) => ZIO.unit
 
-  lazy val Default: ServerLogger[Any] = ServerLogger(defaultInfoLogger, defaultRequestLogger, defaultErrorLogger, noLog)
-  lazy val Debug: ServerLogger[Any] = Default.copy(debug = defaultDebugLogger)
+  lazy val Default: ServerLogger[Any] = ServerLogger(defaultInfoLogger, defaultRequestLogger, defaultErrorLogger, noLogErrors, noLog)
+  lazy val Debug: ServerLogger[Any] = Default.copy(debug = defaultDebugLogger, )
   lazy val Quiet: ServerLogger[Any] = Default.copy(info = noLog, request = noLogRequests)
-  lazy val Silent: ServerLogger[Any] = Quiet.copy(error = (_, _) => ZIO.unit)
+  lazy val Silent: ServerLogger[Any] = Quiet.copy(error = noLogErrors)
 }

--- a/src/main/scala/uzhttp/server/package.scala
+++ b/src/main/scala/uzhttp/server/package.scala
@@ -14,6 +14,7 @@ package object server {
     def request(req: Request, rep: Response, startDuration: Duration, finishDuration: Duration): URIO[Logging, Unit] = ZIO.accessM[Logging](_.get[ServerLogger[Any]].request(req, rep, startDuration, finishDuration))
     def debug(str: => String): URIO[Logging, Unit] = ZIO.accessM[Logging](_.get[ServerLogger[Any]].debug(str))
     def error(str: String, err: Throwable): URIO[Logging, Unit] = ZIO.accessM[Logging](_.get[ServerLogger[Any]].error(str, err))
+    def debugError(str: String, err: Throwable): URIO[Logging, Unit] = ZIO.accessM[Logging](_.get[ServerLogger[Any]].debugError(str, err))
   }
 
   private[server] val EmptyLine: Array[Byte] = CRLF ++ CRLF


### PR DESCRIPTION
- Add a `debugError` logger that most errors use (because most errors are of the variety "Client connection closed when I didn't expect it" and that is just pointless noise most of the time). By default this output is disabled.
- Ensure closing of a connection after response is written (if response should close) and close connection if there's an interruption or failure in writing