### PR TITLE
Close responses when the connection closes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 organization := "org.polynote"
 name := "uzhttp"
-version := "0.1.3-SNAPSHOT"
+version := "0.1.3"
 scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 


### PR DESCRIPTION
Currently just for websocket responses – if the connection closes, the response should get some kind of indication so it can stop writing. Responses generally take a lock on connection writing, and that lock is also needed to close the response (otherwise a response could be interrupted in the middle which would be bad). But websocket responses don't have a thing like, "I gotta write this many bytes and then I'm done!" so we should be able to interrupt them if the client closes the connection.