### PR TITLE
Fix ZTransducer usage, improve performance, update to ZIO RC-19-1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 
 organization := "org.polynote"
 name := "uzhttp"
-version := "0.2.0"
+version := "0.2.1-SNAPSHOT"
 scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
-val zioVersion = "1.0.0-RC19"
+val zioVersion = "1.0.0-RC19-1"
 
 libraryDependencies := Seq(
   "dev.zio" %% "zio" % zioVersion,

--- a/src/main/scala/uzhttp/websocket/Frame.scala
+++ b/src/main/scala/uzhttp/websocket/Frame.scala
@@ -3,7 +3,7 @@ package uzhttp.websocket
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-import zio.{Chunk, Ref, ZIO}
+import zio.{Chunk, Ref, ZIO, ZManaged}
 import zio.stream.{Sink, Stream, ZSink, ZStream, ZTransducer}
 import ZStream.Take
 import Frame.frameBytes
@@ -26,106 +26,241 @@ object Frame {
     case _ => throw new IllegalArgumentException("Invalid frame opcode")
   }
 
+
   final case class FrameHeader(fin: Boolean, opcode: Byte, mask: Boolean, lengthIndicator: Byte)
 
-  sealed trait State
-  final case class NeedHeader(bytes: Chunk[Byte]) extends State
-  final case class NeedShortLength(bytes: Chunk[Byte], header: FrameHeader) extends State
-  final case class NeedLongLength(bytes: Chunk[Byte], header: FrameHeader) extends State
-  final case class NeedMask(bytes: Chunk[Byte], header: FrameHeader, length: Int) extends State
-  final case class ParsingFrame(bytes: Chunk[Byte], header: FrameHeader, length: Int, maskBytes: Int) extends State
-  final case class Fail(err: FrameError) extends State
-  final case class Emit(frame: Frame, remainder: Chunk[Byte]) extends State
+  /**
+    * Parsing using mutable state. That's not good, but it is several times faster than the immutable state version.
+    */
+  private object FastParsing {
+    val NeedHeader      = 0
+    val NeedShortLength = 1
+    val NeedLongLength  = 2
+    val NeedMask        = 3
+    val ReceivingBytes  = 4
+    val LengthTooLong   = 5
 
-  @tailrec
-  def nextState(state: State, chunk: Chunk[Byte]): State = state match {
-    case NeedHeader(prevBytes) =>
-      val bytes = prevBytes ++ chunk
-      if (bytes.size >= 2) {
+    // this is mutable in order to avoid a lot of allocation during parsing
+    final class State(
+     var parsingState: Int = NeedHeader,
+     var header: FrameHeader = null,
+     var length: Int = -1,
+     var maskKey: Int = 0,
+     var remainder: Chunk[Byte] = Chunk.empty,
+     var parsedFrames: Chunk[Frame] = Chunk.empty
+    ) {
+      val bufArray: Array[Byte] = new Array[Byte](10)
+      val buf: ByteBuffer = ByteBuffer.wrap(bufArray)
+      def reset(): Unit = {
+        this.parsingState = NeedHeader
+        this.header = null
+        this.length = -1
+        this.maskKey = 0
+        ()
+      }
+
+      def emit(): Chunk[Frame] = {
+        val result = this.parsedFrames
+        this.parsedFrames = Chunk.empty
+        result
+      }
+
+      def emitAndReset(): Chunk[Frame] = {
+        this.reset()
+        this.remainder = Chunk.empty
+        this.emit()
+      }
+    }
+
+    @tailrec def updateState(state: State): Unit = {
+      val bytes = state.remainder
+      state.parsingState match {
+        case NeedHeader if bytes.size >= 2 =>
+          val b0 = bytes.head
+          val b1 = bytes(1)
+          val lengthIndicator = (b1 & 127).toByte
+          val mask = b1 < 0
+          state.header = FrameHeader(b0 < 0, (b0 & 0xF).toByte, mask, lengthIndicator)
+          state.parsingState = lengthIndicator match {
+            case 127 => NeedLongLength
+            case 126 => NeedShortLength
+            case n if mask =>
+              state.length = n
+              state.remainder = state.remainder.drop(2)
+              NeedMask
+            case n =>
+              state.length = n
+              ReceivingBytes
+          }
+          updateState(state)
+        case NeedShortLength if bytes.size >= 4 =>
+          state.bufArray(0) = bytes(2)
+          state.bufArray(1) = bytes(3)
+          state.length = java.lang.Short.toUnsignedInt(state.buf.getShort(0))
+          state.remainder = state.remainder.drop(4)
+          state.parsingState = if (state.header.mask) NeedMask else ReceivingBytes
+          updateState(state)
+        case NeedLongLength if bytes.size >= 10 =>
+          bytes.copyToArray(state.bufArray, 0, 10)
+          val length = state.buf.getLong(2)
+          if (length > Int.MaxValue) {
+            state.parsingState = LengthTooLong
+          } else {
+            state.length = length.toInt
+            state.remainder = state.remainder.drop(10)
+            state.parsingState = if (state.header.mask) NeedMask else ReceivingBytes
+            updateState(state)
+          }
+        case NeedMask if bytes.size >= 4 =>
+          bytes.copyToArray(state.bufArray, 0, 4)
+          state.maskKey = state.buf.getInt(0)
+          state.remainder = state.remainder.drop(4)
+          state.parsingState = ReceivingBytes
+          updateState(state)
+        case ReceivingBytes if bytes.size >= state.length =>
+          val body = bytes.take(state.length).toArray
+          if (state.header.mask && state.maskKey != 0) {
+            applyMask(body, state.maskKey)
+          }
+          state.remainder = state.remainder.drop(state.length)
+          state.parsedFrames = state.parsedFrames + Frame(state.header.fin, state.header.opcode, body)
+          state.reset()
+          updateState(state)
+        case _ =>
+      }
+    }
+
+    val parseFrames: ZTransducer[Any, FrameError, Byte, Frame] = ZTransducer.apply[Any, FrameError, Byte, Frame] {
+      ZManaged.succeed(new State()).map {
+        state =>
+          {
+            case None =>
+              updateState(state)
+              if (state.parsingState == LengthTooLong)
+                ZIO.fail(FrameTooLong(state.buf.getLong(2)))
+              else
+                ZIO.succeed(state.emitAndReset())
+            case Some(chunk) =>
+              state.remainder = state.remainder ++ chunk
+              updateState(state)
+              if (state.parsingState == LengthTooLong)
+                ZIO.fail(FrameTooLong(state.buf.getLong(2)))
+              else
+                ZIO.succeed(state.emit())
+          }
+      }
+    }
+  }
+
+  /**
+    * Parsing with immutable state. This turns out to be a lot slower (about 5x slower in my test) so it's not used.
+    * But, I've left it here so it can maybe be improved upon.
+    */
+  private object PrincipledParsing {
+
+    sealed abstract class FrameState(val bytesNeeded: Int) {
+      def next(neededBytes: Chunk[Byte]): FrameState
+    }
+
+    case object NeedHeader extends FrameState(2) {
+      override def next(bytes: Chunk[Byte]): FrameState = {
         val b0 = bytes.head
         val b1 = bytes(1)
         val lengthIndicator = (b1 & 127).toByte
         val frameHeader = FrameHeader(b0 < 0, (b0 & 0xF).toByte, b1 < 0, (b1 & 127).toByte)
-        val accum = bytes.drop(2)
-        val next = lengthIndicator match {
-          case 127 => NeedLongLength(accum, frameHeader)
-          case 126 => NeedShortLength(accum, frameHeader)
-          case n if frameHeader.mask => NeedMask(accum, frameHeader, n)
-          case n => ParsingFrame(accum, frameHeader, java.lang.Byte.toUnsignedInt(n), 0)
+        val nextFrameState = lengthIndicator match {
+          case 127 => NeedLongLength(frameHeader)
+          case 126 => NeedShortLength(frameHeader)
+          case n if frameHeader.mask => NeedMask(frameHeader, n)
+          case n => ParsingFrame(frameHeader, java.lang.Byte.toUnsignedInt(n), 0)
         }
-        nextState(next, Chunk.empty)
-      } else NeedHeader(bytes)
-    case NeedShortLength(prevBytes, header) =>
-      val bytes = prevBytes ++ chunk
-      if (bytes.size >= 2) {
+        nextFrameState
+      }
+    }
+
+    final case class NeedShortLength(header: FrameHeader) extends FrameState(2) {
+      override def next(bytes: Chunk[Byte]): FrameState = {
         val b0 = bytes.head
         val b1 = bytes(1)
         val length = (java.lang.Byte.toUnsignedInt(b0) << 8) | java.lang.Byte.toUnsignedInt(b1)
-        val accum = bytes.drop(2)
-        val next = if (header.mask) {
-          NeedMask(accum, header, length.toInt)
+        if (header.mask) {
+          NeedMask(header, length)
         } else {
-          ParsingFrame(accum, header, length.toInt, 0)
+          ParsingFrame(header, length, 0)
         }
-        nextState(next, Chunk.empty)
-      } else NeedShortLength(bytes, header)
-    case NeedLongLength(prevBytes, header) =>
-      val bytes = prevBytes ++ chunk
-      if (bytes.size >= 8) {
-        val length = ByteBuffer.wrap(bytes.take(8).toArray).getLong()
+      }
+    }
+
+    final case class NeedLongLength(header: FrameHeader) extends FrameState(8) {
+      override def next(bytes: Chunk[Byte]): FrameState = {
+        val length = ByteBuffer.wrap(bytes.toArray).getLong()
         if (length > Int.MaxValue) {
           Fail(FrameTooLong(length))
         } else {
-          val accum = bytes.drop(8)
-          val next = if (header.mask) {
-            NeedMask(accum, header, length.toInt)
+          if (header.mask) {
+            NeedMask(header, length.toInt)
           } else {
-            ParsingFrame(accum, header, length.toInt, 0)
+            ParsingFrame(header, length.toInt, 0)
           }
-          nextState(next, Chunk.empty)
         }
-      } else NeedLongLength(bytes, header)
-    case NeedMask(prevBytes, header, length) =>
-      val bytes = prevBytes ++ chunk
-      if (bytes.size >= 4) {
-        val mask = ByteBuffer.wrap(bytes.take(4).toArray).getInt()
-        val accum = bytes.drop(4)
-        nextState(ParsingFrame(accum, header, length, mask), Chunk.empty)
-      } else NeedMask(bytes, header, length)
-    case ParsingFrame(prevBytes, header, length, maskKey) =>
-      val bytes = prevBytes ++ chunk
-      if (bytes.length >= length) {
-        val body = bytes.take(length).toArray
-        if (header.mask) {
-          applyMask(body, maskKey)
-        }
-        val remainder = bytes.drop(length)
-        Emit(Frame(header.fin, header.opcode, body), remainder)
-      } else ParsingFrame(bytes, header, length, maskKey)
-    case fail@Fail(_) => fail
-    case Emit(_, remainder) =>
-      nextState(NeedHeader(remainder), chunk)
-  }
-
-  val parseFrames: ZTransducer[Any, FrameError, Byte, Frame] = ZTransducer.apply[Any, FrameError, Byte, Frame] {
-    Ref.makeManaged[State](NeedHeader(Chunk.empty)).map { stateRef =>
-      {
-        case None =>
-          stateRef.getAndSet(NeedHeader(Chunk.empty)).map {
-            case Emit(frame, _) => Chunk(frame)
-            case _              => Chunk.empty
-          }
-        case Some(chunk) =>
-          stateRef.updateAndGet(state => nextState(state, chunk)).flatMap {
-            case Emit(frame, remainder) =>
-              stateRef.set(NeedHeader(remainder)).as(Chunk(frame))
-            case Fail(err)              =>
-              ZIO.fail(err)
-            case _                      =>
-              ZIO.succeed(Chunk.empty)
-          }
       }
     }
+
+    final case class NeedMask(header: FrameHeader, length: Int) extends FrameState(4) {
+      override def next(bytes: Chunk[Byte]): FrameState = ParsingFrame(header, length, ByteBuffer.wrap(bytes.toArray).getInt())
+    }
+
+    final case class ParsingFrame(header: FrameHeader, length: Int, maskBytes: Int) extends FrameState(length) {
+      override def next(bytes: Chunk[Byte]): FrameState = NeedHeader
+    }
+
+    final case class Fail(err: FrameError) extends FrameState(0) {
+      override def next(neededBytes: Chunk[Byte]): FrameState = this
+    }
+
+    final case class State(parserState: FrameState, remaining: Chunk[Byte], emit: Chunk[Frame])
+
+    object State {
+      val Empty: State = State(NeedHeader, Chunk.empty, Chunk.empty)
+    }
+
+    @tailrec
+    def nextState(state: State, chunk: Chunk[Byte]): State = {
+      val bytes = state.remaining ++ chunk
+      val needBytes = state.parserState.bytesNeeded
+      if (bytes.size >= needBytes) {
+        state.parserState match {
+          case ParsingFrame(header, length, maskKey) =>
+            val body = bytes.take(length).toArray
+            if (header.mask) {
+              applyMask(body, maskKey)
+            }
+            val remainder = bytes.drop(length)
+            nextState(State(NeedHeader, remainder, state.emit + Frame(header.fin, header.opcode, body)), Chunk.empty)
+          case parserState =>
+            nextState(State(parserState.next(bytes.take(needBytes)), bytes.drop(needBytes), state.emit), Chunk.empty)
+        }
+      } else {
+        state.copy(remaining = bytes)
+      }
+    }
+
+    val parseFrames: ZTransducer[Any, FrameError, Byte, Frame] = ZTransducer.apply[Any, FrameError, Byte, Frame] {
+      Ref.makeManaged(State.Empty).map {
+        stateRef => {
+          case None =>
+            stateRef.updateAndGet(state => nextState(state, Chunk.empty)).flatMap {
+              state => stateRef.set(State.Empty).as(state.emit)
+            }
+          case Some(chunk) =>
+            stateRef.updateAndGet(state => nextState(state, chunk)).flatMap {
+              case State(Fail(err), _, _) => ZIO.fail(err)
+              case _                      => stateRef.getAndUpdate(_.copy(emit = Chunk.empty)).map(_.emit)
+            }
+        }
+      }
+    }
+
   }
 
   // mask the given bytes with the given key, mutating the input array
@@ -146,14 +281,12 @@ object Frame {
     }
   }
 
-
-  // Parses websocket frames from the bytestream using the parseFrame sink
-  private[uzhttp] def parse(stream: Stream[Throwable, Byte]): Stream[Throwable, Frame] = stream.aggregate(parseFrames)
+  // Parses websocket frames from the bytestream using the parseFrame transducer
+  private[uzhttp] def parse(stream: Stream[Throwable, Byte]): Stream[Throwable, Frame] = stream.aggregate(FastParsing.parseFrames)
 
   sealed abstract class FrameError(msg: String) extends Throwable(msg)
   // We don't handle frames that are over 2GB, because Java can't handle their length.
   final case class FrameTooLong(length: Long) extends FrameError(s"Frame length $length exceeds Int.MaxValue")
-  case object NotEnoughBytes extends FrameError("Not enough bytes remaining")
 
   private[websocket] def frameSize(payloadLength: Int) =
     if (payloadLength < 126)


### PR DESCRIPTION
- Fixed improper usage of `ZTransducer`, which caused websocket frames not to be emitted eagerly enough
- Added a websocket frame parser that uses mutable state, which has much better performance (I think this is safe, because the transducer's `Managed` instance isn't shared across streams). This is now what's used, even though it's filthy and objectionable
- Update ZIO to 1.0.0-RC19-1