### PR TITLE
Respect headers for streaming responses

### DIFF
--- a/src/main/scala/uzhttp/Response.scala
+++ b/src/main/scala/uzhttp/Response.scala
@@ -247,7 +247,7 @@ object Response {
     override def addHeaders(headers: (String, String)*): ByteStreamResponse = copy(headers = this.headers ++ headers)
     override def removeHeader(name: String): Response = copy(headers = headers.removed(name))
     override private[uzhttp] def writeTo(connection: Server.ConnectionWriter): ZIO[Blocking, Throwable, Unit] =
-      connection.writeByteArrays(body)
+      connection.writeByteArrays(Stream(Response.headerBytes(this)).concat(body))
   }
 
   private final case class ConstResponse private[uzhttp] (


### PR DESCRIPTION
This bit me when using streaming responses.

Since all APIs above accept headers it surprised me that those were never actually used but had to be manually prepended to the beginning of the response stream.